### PR TITLE
Corrigindo erro de atributo no comando info servidor.

### DIFF
--- a/components/commands/info.py
+++ b/components/commands/info.py
@@ -18,7 +18,7 @@ class Info(commands.GroupCog, group_name="info"):
     async def serverinfo(self, interaction: discord.Interaction):
         server = interaction.guild
         embed = discord.Embed(title=f"INFORMAÇÕES DO SERVIDOR", color=0x7575FF)
-        if server.icon.url is not None:
+        if server.icon:
             embed.set_author(name=server.name, icon_url=server.icon.url)
         else:
             embed.set_author(name=server.name)


### PR DESCRIPTION
Corrigir erro onde caso o servidor não tenha um ícone o bot não irá conseguir pegar a url do servidor e irá gerar um erro impossibilitando o usuário de utilizar o comando.
![Screenshot_20240612-212243](https://github.com/Kaycfarias/tanyamydiscordbot/assets/105124579/58e9a2d2-3973-4a7c-af1f-4b463e022c05)
